### PR TITLE
Fixing broken logo image

### DIFF
--- a/docs/categories/auto-generators.html
+++ b/docs/categories/auto-generators.html
@@ -20,7 +20,7 @@
       <div class="lg:w-auto lg:flex-1">
         <div class="flex">
           <a href="/"><img class="object-contain h-16 w-44" alt="OpenAPI Initiative"
-              src="https://www.openapis.org/wp-content/uploads/sites/3/2018/02/OpenAPI_Logo_Pantone-1.png"></a>
+              src="https://www.openapis.org/wp-content/uploads/sites/31/2018/02/OpenAPI_Logo_Pantone-1.png"></a>
           <nav class="hidden lg:flex lg:items-center lg:justify-end space-x-6 xl:space-x-10 w-full">
 
             <a target="_self" rel="noopener noreferrer"

--- a/docs/categories/client-implementations.html
+++ b/docs/categories/client-implementations.html
@@ -20,7 +20,7 @@
       <div class="lg:w-auto lg:flex-1">
         <div class="flex">
           <a href="/"><img class="object-contain h-16 w-44" alt="OpenAPI Initiative"
-              src="https://www.openapis.org/wp-content/uploads/sites/3/2018/02/OpenAPI_Logo_Pantone-1.png"></a>
+              src="https://www.openapis.org/wp-content/uploads/sites/31/2018/02/OpenAPI_Logo_Pantone-1.png"></a>
           <nav class="hidden lg:flex lg:items-center lg:justify-end space-x-6 xl:space-x-10 w-full">
 
             <a target="_self" rel="noopener noreferrer"

--- a/docs/categories/code-generators.html
+++ b/docs/categories/code-generators.html
@@ -20,7 +20,7 @@
       <div class="lg:w-auto lg:flex-1">
         <div class="flex">
           <a href="/"><img class="object-contain h-16 w-44" alt="OpenAPI Initiative"
-              src="https://www.openapis.org/wp-content/uploads/sites/3/2018/02/OpenAPI_Logo_Pantone-1.png"></a>
+              src="https://www.openapis.org/wp-content/uploads/sites/31/2018/02/OpenAPI_Logo_Pantone-1.png"></a>
           <nav class="hidden lg:flex lg:items-center lg:justify-end space-x-6 xl:space-x-10 w-full">
 
             <a target="_self" rel="noopener noreferrer"

--- a/docs/categories/converters.html
+++ b/docs/categories/converters.html
@@ -20,7 +20,7 @@
       <div class="lg:w-auto lg:flex-1">
         <div class="flex">
           <a href="/"><img class="object-contain h-16 w-44" alt="OpenAPI Initiative"
-              src="https://www.openapis.org/wp-content/uploads/sites/3/2018/02/OpenAPI_Logo_Pantone-1.png"></a>
+              src="https://www.openapis.org/wp-content/uploads/sites/31/2018/02/OpenAPI_Logo_Pantone-1.png"></a>
           <nav class="hidden lg:flex lg:items-center lg:justify-end space-x-6 xl:space-x-10 w-full">
 
             <a target="_self" rel="noopener noreferrer"

--- a/docs/categories/data-validators.html
+++ b/docs/categories/data-validators.html
@@ -20,7 +20,7 @@
       <div class="lg:w-auto lg:flex-1">
         <div class="flex">
           <a href="/"><img class="object-contain h-16 w-44" alt="OpenAPI Initiative"
-              src="https://www.openapis.org/wp-content/uploads/sites/3/2018/02/OpenAPI_Logo_Pantone-1.png"></a>
+              src="https://www.openapis.org/wp-content/uploads/sites/31/2018/02/OpenAPI_Logo_Pantone-1.png"></a>
           <nav class="hidden lg:flex lg:items-center lg:justify-end space-x-6 xl:space-x-10 w-full">
 
             <a target="_self" rel="noopener noreferrer"

--- a/docs/categories/description-validators.html
+++ b/docs/categories/description-validators.html
@@ -20,7 +20,7 @@
       <div class="lg:w-auto lg:flex-1">
         <div class="flex">
           <a href="/"><img class="object-contain h-16 w-44" alt="OpenAPI Initiative"
-              src="https://www.openapis.org/wp-content/uploads/sites/3/2018/02/OpenAPI_Logo_Pantone-1.png"></a>
+              src="https://www.openapis.org/wp-content/uploads/sites/31/2018/02/OpenAPI_Logo_Pantone-1.png"></a>
           <nav class="hidden lg:flex lg:items-center lg:justify-end space-x-6 xl:space-x-10 w-full">
 
             <a target="_self" rel="noopener noreferrer"

--- a/docs/categories/documentation.html
+++ b/docs/categories/documentation.html
@@ -20,7 +20,7 @@
       <div class="lg:w-auto lg:flex-1">
         <div class="flex">
           <a href="/"><img class="object-contain h-16 w-44" alt="OpenAPI Initiative"
-              src="https://www.openapis.org/wp-content/uploads/sites/3/2018/02/OpenAPI_Logo_Pantone-1.png"></a>
+              src="https://www.openapis.org/wp-content/uploads/sites/31/2018/02/OpenAPI_Logo_Pantone-1.png"></a>
           <nav class="hidden lg:flex lg:items-center lg:justify-end space-x-6 xl:space-x-10 w-full">
 
             <a target="_self" rel="noopener noreferrer"

--- a/docs/categories/dsl.html
+++ b/docs/categories/dsl.html
@@ -20,7 +20,7 @@
       <div class="lg:w-auto lg:flex-1">
         <div class="flex">
           <a href="/"><img class="object-contain h-16 w-44" alt="OpenAPI Initiative"
-              src="https://www.openapis.org/wp-content/uploads/sites/3/2018/02/OpenAPI_Logo_Pantone-1.png"></a>
+              src="https://www.openapis.org/wp-content/uploads/sites/31/2018/02/OpenAPI_Logo_Pantone-1.png"></a>
           <nav class="hidden lg:flex lg:items-center lg:justify-end space-x-6 xl:space-x-10 w-full">
 
             <a target="_self" rel="noopener noreferrer"

--- a/docs/categories/editors.html
+++ b/docs/categories/editors.html
@@ -20,7 +20,7 @@
       <div class="lg:w-auto lg:flex-1">
         <div class="flex">
           <a href="/"><img class="object-contain h-16 w-44" alt="OpenAPI Initiative"
-              src="https://www.openapis.org/wp-content/uploads/sites/3/2018/02/OpenAPI_Logo_Pantone-1.png"></a>
+              src="https://www.openapis.org/wp-content/uploads/sites/31/2018/02/OpenAPI_Logo_Pantone-1.png"></a>
           <nav class="hidden lg:flex lg:items-center lg:justify-end space-x-6 xl:space-x-10 w-full">
 
             <a target="_self" rel="noopener noreferrer"

--- a/docs/categories/gateway.html
+++ b/docs/categories/gateway.html
@@ -20,7 +20,7 @@
       <div class="lg:w-auto lg:flex-1">
         <div class="flex">
           <a href="/"><img class="object-contain h-16 w-44" alt="OpenAPI Initiative"
-              src="https://www.openapis.org/wp-content/uploads/sites/3/2018/02/OpenAPI_Logo_Pantone-1.png"></a>
+              src="https://www.openapis.org/wp-content/uploads/sites/31/2018/02/OpenAPI_Logo_Pantone-1.png"></a>
           <nav class="hidden lg:flex lg:items-center lg:justify-end space-x-6 xl:space-x-10 w-full">
 
             <a target="_self" rel="noopener noreferrer"

--- a/docs/categories/gui-editors.html
+++ b/docs/categories/gui-editors.html
@@ -20,7 +20,7 @@
       <div class="lg:w-auto lg:flex-1">
         <div class="flex">
           <a href="/"><img class="object-contain h-16 w-44" alt="OpenAPI Initiative"
-              src="https://www.openapis.org/wp-content/uploads/sites/3/2018/02/OpenAPI_Logo_Pantone-1.png"></a>
+              src="https://www.openapis.org/wp-content/uploads/sites/31/2018/02/OpenAPI_Logo_Pantone-1.png"></a>
           <nav class="hidden lg:flex lg:items-center lg:justify-end space-x-6 xl:space-x-10 w-full">
 
             <a target="_self" rel="noopener noreferrer"

--- a/docs/categories/learning.html
+++ b/docs/categories/learning.html
@@ -20,7 +20,7 @@
       <div class="lg:w-auto lg:flex-1">
         <div class="flex">
           <a href="/"><img class="object-contain h-16 w-44" alt="OpenAPI Initiative"
-              src="https://www.openapis.org/wp-content/uploads/sites/3/2018/02/OpenAPI_Logo_Pantone-1.png"></a>
+              src="https://www.openapis.org/wp-content/uploads/sites/31/2018/02/OpenAPI_Logo_Pantone-1.png"></a>
           <nav class="hidden lg:flex lg:items-center lg:justify-end space-x-6 xl:space-x-10 w-full">
 
             <a target="_self" rel="noopener noreferrer"

--- a/docs/categories/low-level-tooling.html
+++ b/docs/categories/low-level-tooling.html
@@ -20,7 +20,7 @@
       <div class="lg:w-auto lg:flex-1">
         <div class="flex">
           <a href="/"><img class="object-contain h-16 w-44" alt="OpenAPI Initiative"
-              src="https://www.openapis.org/wp-content/uploads/sites/3/2018/02/OpenAPI_Logo_Pantone-1.png"></a>
+              src="https://www.openapis.org/wp-content/uploads/sites/31/2018/02/OpenAPI_Logo_Pantone-1.png"></a>
           <nav class="hidden lg:flex lg:items-center lg:justify-end space-x-6 xl:space-x-10 w-full">
 
             <a target="_self" rel="noopener noreferrer"

--- a/docs/categories/mock-testing.html
+++ b/docs/categories/mock-testing.html
@@ -20,7 +20,7 @@
       <div class="lg:w-auto lg:flex-1">
         <div class="flex">
           <a href="/"><img class="object-contain h-16 w-44" alt="OpenAPI Initiative"
-              src="https://www.openapis.org/wp-content/uploads/sites/3/2018/02/OpenAPI_Logo_Pantone-1.png"></a>
+              src="https://www.openapis.org/wp-content/uploads/sites/31/2018/02/OpenAPI_Logo_Pantone-1.png"></a>
           <nav class="hidden lg:flex lg:items-center lg:justify-end space-x-6 xl:space-x-10 w-full">
 
             <a target="_self" rel="noopener noreferrer"

--- a/docs/categories/mock.html
+++ b/docs/categories/mock.html
@@ -20,7 +20,7 @@
       <div class="lg:w-auto lg:flex-1">
         <div class="flex">
           <a href="/"><img class="object-contain h-16 w-44" alt="OpenAPI Initiative"
-              src="https://www.openapis.org/wp-content/uploads/sites/3/2018/02/OpenAPI_Logo_Pantone-1.png"></a>
+              src="https://www.openapis.org/wp-content/uploads/sites/31/2018/02/OpenAPI_Logo_Pantone-1.png"></a>
           <nav class="hidden lg:flex lg:items-center lg:justify-end space-x-6 xl:space-x-10 w-full">
 
             <a target="_self" rel="noopener noreferrer"

--- a/docs/categories/monitoring.html
+++ b/docs/categories/monitoring.html
@@ -20,7 +20,7 @@
       <div class="lg:w-auto lg:flex-1">
         <div class="flex">
           <a href="/"><img class="object-contain h-16 w-44" alt="OpenAPI Initiative"
-              src="https://www.openapis.org/wp-content/uploads/sites/3/2018/02/OpenAPI_Logo_Pantone-1.png"></a>
+              src="https://www.openapis.org/wp-content/uploads/sites/31/2018/02/OpenAPI_Logo_Pantone-1.png"></a>
           <nav class="hidden lg:flex lg:items-center lg:justify-end space-x-6 xl:space-x-10 w-full">
 
             <a target="_self" rel="noopener noreferrer"

--- a/docs/categories/parsers.html
+++ b/docs/categories/parsers.html
@@ -20,7 +20,7 @@
       <div class="lg:w-auto lg:flex-1">
         <div class="flex">
           <a href="/"><img class="object-contain h-16 w-44" alt="OpenAPI Initiative"
-              src="https://www.openapis.org/wp-content/uploads/sites/3/2018/02/OpenAPI_Logo_Pantone-1.png"></a>
+              src="https://www.openapis.org/wp-content/uploads/sites/31/2018/02/OpenAPI_Logo_Pantone-1.png"></a>
           <nav class="hidden lg:flex lg:items-center lg:justify-end space-x-6 xl:space-x-10 w-full">
 
             <a target="_self" rel="noopener noreferrer"

--- a/docs/categories/schema-validators.html
+++ b/docs/categories/schema-validators.html
@@ -20,7 +20,7 @@
       <div class="lg:w-auto lg:flex-1">
         <div class="flex">
           <a href="/"><img class="object-contain h-16 w-44" alt="OpenAPI Initiative"
-              src="https://www.openapis.org/wp-content/uploads/sites/3/2018/02/OpenAPI_Logo_Pantone-1.png"></a>
+              src="https://www.openapis.org/wp-content/uploads/sites/31/2018/02/OpenAPI_Logo_Pantone-1.png"></a>
           <nav class="hidden lg:flex lg:items-center lg:justify-end space-x-6 xl:space-x-10 w-full">
 
             <a target="_self" rel="noopener noreferrer"

--- a/docs/categories/sdk.html
+++ b/docs/categories/sdk.html
@@ -20,7 +20,7 @@
       <div class="lg:w-auto lg:flex-1">
         <div class="flex">
           <a href="/"><img class="object-contain h-16 w-44" alt="OpenAPI Initiative"
-              src="https://www.openapis.org/wp-content/uploads/sites/3/2018/02/OpenAPI_Logo_Pantone-1.png"></a>
+              src="https://www.openapis.org/wp-content/uploads/sites/31/2018/02/OpenAPI_Logo_Pantone-1.png"></a>
           <nav class="hidden lg:flex lg:items-center lg:justify-end space-x-6 xl:space-x-10 w-full">
 
             <a target="_self" rel="noopener noreferrer"

--- a/docs/categories/security.html
+++ b/docs/categories/security.html
@@ -20,7 +20,7 @@
       <div class="lg:w-auto lg:flex-1">
         <div class="flex">
           <a href="/"><img class="object-contain h-16 w-44" alt="OpenAPI Initiative"
-              src="https://www.openapis.org/wp-content/uploads/sites/3/2018/02/OpenAPI_Logo_Pantone-1.png"></a>
+              src="https://www.openapis.org/wp-content/uploads/sites/31/2018/02/OpenAPI_Logo_Pantone-1.png"></a>
           <nav class="hidden lg:flex lg:items-center lg:justify-end space-x-6 xl:space-x-10 w-full">
 
             <a target="_self" rel="noopener noreferrer"

--- a/docs/categories/server-implementations.html
+++ b/docs/categories/server-implementations.html
@@ -20,7 +20,7 @@
       <div class="lg:w-auto lg:flex-1">
         <div class="flex">
           <a href="/"><img class="object-contain h-16 w-44" alt="OpenAPI Initiative"
-              src="https://www.openapis.org/wp-content/uploads/sites/3/2018/02/OpenAPI_Logo_Pantone-1.png"></a>
+              src="https://www.openapis.org/wp-content/uploads/sites/31/2018/02/OpenAPI_Logo_Pantone-1.png"></a>
           <nav class="hidden lg:flex lg:items-center lg:justify-end space-x-6 xl:space-x-10 w-full">
 
             <a target="_self" rel="noopener noreferrer"

--- a/docs/categories/server.html
+++ b/docs/categories/server.html
@@ -20,7 +20,7 @@
       <div class="lg:w-auto lg:flex-1">
         <div class="flex">
           <a href="/"><img class="object-contain h-16 w-44" alt="OpenAPI Initiative"
-              src="https://www.openapis.org/wp-content/uploads/sites/3/2018/02/OpenAPI_Logo_Pantone-1.png"></a>
+              src="https://www.openapis.org/wp-content/uploads/sites/31/2018/02/OpenAPI_Logo_Pantone-1.png"></a>
           <nav class="hidden lg:flex lg:items-center lg:justify-end space-x-6 xl:space-x-10 w-full">
 
             <a target="_self" rel="noopener noreferrer"

--- a/docs/categories/testing-tools.html
+++ b/docs/categories/testing-tools.html
@@ -20,7 +20,7 @@
       <div class="lg:w-auto lg:flex-1">
         <div class="flex">
           <a href="/"><img class="object-contain h-16 w-44" alt="OpenAPI Initiative"
-              src="https://www.openapis.org/wp-content/uploads/sites/3/2018/02/OpenAPI_Logo_Pantone-1.png"></a>
+              src="https://www.openapis.org/wp-content/uploads/sites/31/2018/02/OpenAPI_Logo_Pantone-1.png"></a>
           <nav class="hidden lg:flex lg:items-center lg:justify-end space-x-6 xl:space-x-10 w-full">
 
             <a target="_self" rel="noopener noreferrer"

--- a/docs/categories/testing.html
+++ b/docs/categories/testing.html
@@ -20,7 +20,7 @@
       <div class="lg:w-auto lg:flex-1">
         <div class="flex">
           <a href="/"><img class="object-contain h-16 w-44" alt="OpenAPI Initiative"
-              src="https://www.openapis.org/wp-content/uploads/sites/3/2018/02/OpenAPI_Logo_Pantone-1.png"></a>
+              src="https://www.openapis.org/wp-content/uploads/sites/31/2018/02/OpenAPI_Logo_Pantone-1.png"></a>
           <nav class="hidden lg:flex lg:items-center lg:justify-end space-x-6 xl:space-x-10 w-full">
 
             <a target="_self" rel="noopener noreferrer"

--- a/docs/categories/text-editors.html
+++ b/docs/categories/text-editors.html
@@ -20,7 +20,7 @@
       <div class="lg:w-auto lg:flex-1">
         <div class="flex">
           <a href="/"><img class="object-contain h-16 w-44" alt="OpenAPI Initiative"
-              src="https://www.openapis.org/wp-content/uploads/sites/3/2018/02/OpenAPI_Logo_Pantone-1.png"></a>
+              src="https://www.openapis.org/wp-content/uploads/sites/31/2018/02/OpenAPI_Logo_Pantone-1.png"></a>
           <nav class="hidden lg:flex lg:items-center lg:justify-end space-x-6 xl:space-x-10 w-full">
 
             <a target="_self" rel="noopener noreferrer"

--- a/docs/categories/unclassified.html
+++ b/docs/categories/unclassified.html
@@ -20,7 +20,7 @@
       <div class="lg:w-auto lg:flex-1">
         <div class="flex">
           <a href="/"><img class="object-contain h-16 w-44" alt="OpenAPI Initiative"
-              src="https://www.openapis.org/wp-content/uploads/sites/3/2018/02/OpenAPI_Logo_Pantone-1.png"></a>
+              src="https://www.openapis.org/wp-content/uploads/sites/31/2018/02/OpenAPI_Logo_Pantone-1.png"></a>
           <nav class="hidden lg:flex lg:items-center lg:justify-end space-x-6 xl:space-x-10 w-full">
 
             <a target="_self" rel="noopener noreferrer"

--- a/docs/categories/user-interfaces.html
+++ b/docs/categories/user-interfaces.html
@@ -20,7 +20,7 @@
       <div class="lg:w-auto lg:flex-1">
         <div class="flex">
           <a href="/"><img class="object-contain h-16 w-44" alt="OpenAPI Initiative"
-              src="https://www.openapis.org/wp-content/uploads/sites/3/2018/02/OpenAPI_Logo_Pantone-1.png"></a>
+              src="https://www.openapis.org/wp-content/uploads/sites/31/2018/02/OpenAPI_Logo_Pantone-1.png"></a>
           <nav class="hidden lg:flex lg:items-center lg:justify-end space-x-6 xl:space-x-10 w-full">
 
             <a target="_self" rel="noopener noreferrer"

--- a/docs/categories/validator.html
+++ b/docs/categories/validator.html
@@ -20,7 +20,7 @@
       <div class="lg:w-auto lg:flex-1">
         <div class="flex">
           <a href="/"><img class="object-contain h-16 w-44" alt="OpenAPI Initiative"
-              src="https://www.openapis.org/wp-content/uploads/sites/3/2018/02/OpenAPI_Logo_Pantone-1.png"></a>
+              src="https://www.openapis.org/wp-content/uploads/sites/31/2018/02/OpenAPI_Logo_Pantone-1.png"></a>
           <nav class="hidden lg:flex lg:items-center lg:justify-end space-x-6 xl:space-x-10 w-full">
 
             <a target="_self" rel="noopener noreferrer"

--- a/docs/index.html
+++ b/docs/index.html
@@ -22,7 +22,7 @@
       <div class="lg:w-auto lg:flex-1">
         <div class="flex">
           <a href="/"><img class="object-contain h-16 w-44" alt="OpenAPI Initiative"
-              src="https://www.openapis.org/wp-content/uploads/sites/3/2018/02/OpenAPI_Logo_Pantone-1.png"></a>
+              src="https://www.openapis.org/wp-content/uploads/sites/31/2018/02/OpenAPI_Logo_Pantone-1.png"></a>
           <nav class="hidden lg:flex lg:items-center lg:justify-end space-x-6 xl:space-x-10 w-full">
 
             <a target="_self" rel="noopener noreferrer"

--- a/src/_includes/nav-bar.njk
+++ b/src/_includes/nav-bar.njk
@@ -5,7 +5,7 @@
       <div class="lg:w-auto lg:flex-1">
         <div class="flex">
           <a href="{% if hostedAt === true %}/{% else %}{{hostedAt}}{% endif %}"><img class="object-contain h-16 w-44" alt="OpenAPI Initiative"
-              src="https://www.openapis.org/wp-content/uploads/sites/3/2018/02/OpenAPI_Logo_Pantone-1.png"></a>
+              src="https://www.openapis.org/wp-content/uploads/sites/31/2018/02/OpenAPI_Logo_Pantone-1.png"></a>
           <nav class="hidden lg:flex lg:items-center lg:justify-end space-x-6 xl:space-x-10 w-full">
 
             <a target="_self" rel="noopener noreferrer"


### PR DESCRIPTION
Hello,

Thanks for creating this site. Noticed that the logo image is not appearing.

<img width="260" alt="image" src="https://github.com/user-attachments/assets/b5cae414-7ed9-4b22-a912-4daddde7f045" />

Looks like the logo image (https://www.openapis.org/wp-content/uploads/sites/3/2018/02/OpenAPI_Logo_Pantone-1.png) is not available anymore.

<img width="718" alt="image" src="https://github.com/user-attachments/assets/3cca513d-da98-40bb-9bbf-6a22995c1e56" />

I have replaced this logo image with https://www.openapis.org/wp-content/uploads/sites/31/2018/02/OpenAPI_Logo_Pantone-1.png which seems to fix the problem.

<img width="744" alt="image" src="https://github.com/user-attachments/assets/480d49b4-784c-4524-9ef9-379edba76350" />

Hope this helps. Regards.