### PR TITLE
Add Gesso (PHP OpenAPI 3.0/3.1/3.2 contract testing library)

### DIFF
--- a/src/_data/tools.yaml
+++ b/src/_data/tools.yaml
@@ -41498,3 +41498,17 @@
     repoLastModified: Tue, 10 Jun 2025 08:39:30 GMT
   foundInMaster: true
   id: deb9defcd95175a7029de6b81cf1ca78
+- source: https://github.com/studio-design/gesso
+  name: Gesso
+  category: Testing
+  language: PHP
+  source_description: >-
+    Gesso — OpenAPI 3.0/3.1/3.2 contract testing for PHP. Framework-independent
+    core with Laravel, Symfony, Pest, and PSR-7 adapters. PHPUnit
+    endpoint-coverage tracking, request/response validation, schema-driven
+    fuzzing, and drift detection.
+  v2: false
+  v3: true
+  v3_1: true
+  link: https://studio-design.github.io/gesso/
+  repository: https://github.com/studio-design/gesso


### PR DESCRIPTION
Adds [Gesso](https://studio-design.github.io/gesso/) — an MIT-licensed PHP library for OpenAPI 3.0/3.1/3.2 contract testing — to `src/_data/tools.yaml`.

Companion issue: https://github.com/OAI/tools.openapis.org/issues/272

Why a direct YAML PR: the `Full build` workflow has been failing since 2026-07-12, so even though the repo carries `openapi3`, `openapi31`, `openapi-validator`, and `contract-testing` topics, topic-based auto-ingest hasn't fired. Happy to iterate on category / description wording if maintainers prefer a different placement.

Highlights:
- OpenAPI 3.0, 3.1, and 3.2 support (dialect-aware JSON Schema).
- Framework-independent core + Laravel, Symfony, Pest, and PSR-7 adapters.
- PHPUnit endpoint-coverage extension at (method, path, status, content-type) granularity.
- Schema-driven fuzzing with deterministic replay and reduction.
- Enum drift and under-described response detection.
- MIT licensed, no runtime overhead (test-only).

Source: https://github.com/studio-design/gesso
Docs: https://studio-design.github.io/gesso/
License: MIT
